### PR TITLE
Save everything as h5 files instead of pickles

### DIFF
--- a/cropharvest/utils.py
+++ b/cropharvest/utils.py
@@ -1,8 +1,11 @@
 from pathlib import Path
+import h5py
 
 import torch
 import numpy as np
 import random
+
+from typing import Dict
 
 
 DATAFOLDER_PATH = Path(__file__).parent.parent / "data"
@@ -12,3 +15,9 @@ def set_seed(seed: int = 42) -> None:
     np.random.seed(seed)
     torch.manual_seed(seed)
     random.seed(seed)
+
+
+def load_normalizing_dict(path_to_dict: Path) -> Dict[str, np.ndarray]:
+
+    hf = h5py.File(path_to_dict, "r")
+    return {"mean": hf.get("mean"), "std": hf.get("std")}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ xarray
 earthengine-api
 tqdm
 cartopy
+h5py


### PR DESCRIPTION
- [x] All training arrays saved as h5
- [x] All test instances saved as h5
- [x] Normalizing dict saved as h5 

In addition, I've exported the test area for the USA almonds region, and it splits into multiple files; I've updated the test function in the engineer to handle this.