### PR TITLE
Bump cropharvest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author="Gabriel Tseng",
     author_email="gabrieltseng95@gmail.com",
     url="https://github.com/nasaharvest/cropharvest",
-    version="0.1.1",
+    version="0.1.2",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Other/Proprietary License",


### PR DESCRIPTION
Since https://github.com/nasaharvest/cropharvest/pull/49 updated the Zenodo version.