### PR TITLE
Generalizing Exporter

### DIFF
--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -267,7 +267,7 @@ class EarthEngineExporter:
             )
 
             try:
-                export_identifer = row["export_identifier"]
+                export_identifier = row["export_identifier"]
             except KeyError:
                 export_identifier = cls.make_identifier(
                     latlons, row["start_date"], row["end_date"]

--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -89,7 +89,9 @@ class EarthEngineExporter:
         labels = labels.assign(
             start_date=lambda x: x["end_date"] - timedelta(days=DAYS_PER_TIMESTEP * NUM_TIMESTEPS)
         )
-        labels = labels.assign(export_identifier=lambda x: f"{x['index']}-{x['dataset']}")
+        labels = labels.assign(
+            export_identifier=lambda x: f"{x['index']}-{x[RequiredColumns.DATASET]}"
+        )
         return labels
 
     def _filter_labels(self, labels: geopandas.GeoDataFrame) -> geopandas.GeoDataFrame:

--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -39,6 +39,17 @@ STATIC_IMAGE_FUNCTIONS = [get_single_srtm_image]
 
 
 class EarthEngineExporter:
+    """
+    Export satellite data from Earth engine. It's called using the following
+    script:
+    ```
+    from cropharvest.eo import EarthEngineExporter
+
+    exporter = EarthEngineExporter()
+    exporter.export_for_labels()
+    ```
+    """
+
     def __init__(
         self, data_folder: Path = DATAFOLDER_PATH, labels: Optional[geopandas.GeoDataFrame] = None
     ) -> None:
@@ -73,7 +84,7 @@ class EarthEngineExporter:
     @property
     def default_labels(self) -> geopandas.GeoDataFrame:
         labels = geopandas.read_file(self.data_folder / LABELS_FILENAME)
-        export_end_year = pd.to_datetime(self.labels["export_end_date"]).dt.year
+        export_end_year = pd.to_datetime(self.labels[RequiredColumns.EXPORT_END_DATE]).dt.year
         labels["end_date"] = export_end_year.apply(lambda x: date(x, 12, 12))
         labels = labels.assign(
             start_date=lambda x: x["end_date"] - timedelta(days=DAYS_PER_TIMESTEP * NUM_TIMESTEPS)

--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -26,6 +26,7 @@ from cropharvest.config import (
     LABELS_FILENAME,
     TEST_REGIONS,
 )
+from cropharvest.columns import RequiredColumns
 
 from typing import Union, List, Optional, Tuple
 
@@ -59,7 +60,12 @@ class EarthEngineExporter:
 
         self.labels = self.default_labels if labels is None else labels
         self.using_default = labels is None
-        for expected_column in ["start_date", "end_date", "lat", "lon"]:
+        for expected_column in [
+            "start_date",
+            "end_date",
+            RequiredColumns.LAT,
+            RequiredColumns.LON,
+        ]:
             assert expected_column in self.labels
         if "export_identifier" not in self.labels:
             print("No explicit export_identifier in labels. One will be constructed during export")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -e .
 black
 mypy
+flake8==3.*  # https://github.com/tholo/pytest-flake8/issues/81
 pytest-flake8
 pytest-mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -e .
 black
 mypy
-flake8==3.*  # https://github.com/tholo/pytest-flake8/issues/81
+flake8
 pytest-flake8
 pytest-mock

--- a/test/cropharvest/eo/test_eo.py
+++ b/test/cropharvest/eo/test_eo.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from datetime import date
+import pytest
+
+from cropharvest.eo import EarthEngineExporter
+
+
+@pytest.mark.parametrize("with_identifier", (True, False))
+def test_labels_to_polygons_and_years(with_identifier, monkeypatch):
+    data = {
+        "lon": [42],
+        "lat": [0],
+        "start_date": date(2021, 12, 15),
+        "end_date": date(2022, 12, 15),
+    }
+    if with_identifier:
+        data["export_identifier"] = ["hello_world"]
+    labels = pd.DataFrame(data)
+
+    def mock_bb_from_center(mid_lat, mid_lon, surrounding_metres):
+        return (mid_lon - 1, mid_lat - 1, mid_lon + 1, mid_lat + 1), None
+
+    monkeypatch.setattr(EarthEngineExporter, "_bounding_box_from_centre", mock_bb_from_center)
+
+    output = EarthEngineExporter._labels_to_polygons_and_years(labels, surrounding_metres=80)
+
+    assert len(output) == 1
+
+    _, identifier, _, _ = output[0]
+
+    if with_identifier:
+        assert identifier == "hello_world"


### PR DESCRIPTION
Related issue: #55 . This PR will only deal with the labels - specifically, ensuring that the exporter can handle a different `labels` file.

The following tickmarks are copied from #55 - I've only kept the relevant ones:

## Exporting labels
- [x] (1) `labels` should be made input to the export_for_labels() function
- **Why**: crop-mask needs the ability to use the exporter for files outside the public labels.geojson 
- [x] (2) `labels` should be checked for "start_date" and "end_date" and used if they are found
- **Why**: The way that start and end date are computed may vary by dataset, storing this information in the labels prior to exporting leaves the exporter agnostic to this
- [x] (4) Exported tifs should have a canonical name 
- Suggested: `f"min_lat={min_lat}_min_lon={min_lon}_max_lat={max_lat}_max_lon={max_lon}_dates={start_date}_{end_date}_all"` (where the `all` indicates all bands are being exported, not just Sentinel 2)
- **Why**: Making the tifs agnostic to the datasets they are derived from makes it possible to change the underlying dataset without having to reexport all tifs (example use case: partially labeled CEO project csv -> fully labeled CEO project csv)