### PR TITLE
Allow timesteps to be different per dataset item

### DIFF
--- a/cropharvest/config.py
+++ b/cropharvest/config.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 
 DAYS_PER_TIMESTEP = 30
-NUM_TIMESTEPS = 12
+DEFAULT_NUM_TIMESTEPS = 12
 
 # we will export date until the
 # 1st February, at which point

--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -29,7 +29,7 @@ from cropharvest.config import (
     EXPORT_END_DAY,
     EXPORT_END_MONTH,
     DAYS_PER_TIMESTEP,
-    NUM_TIMESTEPS,
+    DEFAULT_NUM_TIMESTEPS,
     LABELS_FILENAME,
     TEST_REGIONS,
 )
@@ -151,7 +151,8 @@ class EarthEngineExporter:
         export_end_year = pd.to_datetime(self.labels[RequiredColumns.EXPORT_END_DATE]).dt.year
         labels["end_date"] = export_end_year.apply(lambda x: date(x, 12, 12))
         labels = labels.assign(
-            start_date=lambda x: x["end_date"] - timedelta(days=DAYS_PER_TIMESTEP * NUM_TIMESTEPS)
+            start_date=lambda x: x["end_date"]
+            - timedelta(days=DAYS_PER_TIMESTEP * DEFAULT_NUM_TIMESTEPS)
         )
         labels = labels.assign(
             export_identifier=lambda x: f"{x['index']}-{x[RequiredColumns.DATASET]}"
@@ -444,7 +445,7 @@ class EarthEngineExporter:
             polygon = self._bbox_to_ee_bounding_box(bbox, padding_metres)
             _, _, year, _ = identifier.split("_")
             end_date = date(int(year), EXPORT_END_MONTH, EXPORT_END_DAY)
-            start_date = end_date - timedelta(days=DAYS_PER_TIMESTEP * NUM_TIMESTEPS)
+            start_date = end_date - timedelta(days=DAYS_PER_TIMESTEP * DEFAULT_NUM_TIMESTEPS)
             _ = self._export_for_polygon(
                 polygon=polygon,
                 polygon_identifier=identifier,

--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -41,7 +41,7 @@ try:
     from google.cloud import storage
 
     GOOGLE_CLOUD_STORAGE_INSTALLED = True
-except ImportError:
+except ModuleNotFoundError:
     GOOGLE_CLOUD_STORAGE_INSTALLED = False
 INSTALL_MSG = "Please install the google-cloud-storage library (pip install google-cloud-storage)"
 

--- a/process_labels/loading_funcs/utils.py
+++ b/process_labels/loading_funcs/utils.py
@@ -3,7 +3,12 @@ import pandas as pd
 from pathlib import Path
 from datetime import datetime, timedelta
 
-from cropharvest.config import EXPORT_END_DAY, EXPORT_END_MONTH, NUM_TIMESTEPS, DAYS_PER_TIMESTEP
+from cropharvest.config import (
+    EXPORT_END_DAY,
+    EXPORT_END_MONTH,
+    DEFAULT_NUM_TIMESTEPS,
+    DAYS_PER_TIMESTEP,
+)
 from cropharvest.columns import RequiredColumns
 
 from typing import Optional, Dict
@@ -69,7 +74,7 @@ def _overlapping_year(harvest_date: datetime, planting_date: datetime) -> int:
         overlap_dict[harvest_year + diff] = _date_overlap(
             planting_date,
             harvest_date,
-            end_date - timedelta(days=NUM_TIMESTEPS * DAYS_PER_TIMESTEP),
+            end_date - timedelta(days=DEFAULT_NUM_TIMESTEPS * DAYS_PER_TIMESTEP),
             end_date,
         )
 

--- a/test/cropharvest/engineer/test_engineer.py
+++ b/test/cropharvest/engineer/test_engineer.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import numpy as np
 
 from cropharvest.engineer import Engineer, BANDS, DYNAMIC_BANDS, STATIC_BANDS
-from cropharvest.config import NUM_TIMESTEPS
+from cropharvest.config import DEFAULT_NUM_TIMESTEPS
 
 from typing import Dict, Union
 
@@ -13,12 +13,12 @@ TIF_FILE = Path(__file__).parent / "98-togo_2019-02-06_2020-02-01.tif"
 def test_load_tif_file():
 
     loaded_file, _ = Engineer.load_tif(TIF_FILE, start_date=datetime(2019, 2, 6))
-    assert loaded_file.shape[0] == NUM_TIMESTEPS
+    assert loaded_file.shape[0] == DEFAULT_NUM_TIMESTEPS
     assert loaded_file.shape[1] == len(DYNAMIC_BANDS) + len(STATIC_BANDS)
 
     # also, check the static bands are actually constant across time
     static_bands = loaded_file.values[:, len(DYNAMIC_BANDS)]
-    for i in range(1, NUM_TIMESTEPS):
+    for i in range(1, DEFAULT_NUM_TIMESTEPS):
         assert np.array_equal(static_bands[0], static_bands[i], equal_nan=True)
 
     # finally, check expected for temperature


### PR DESCRIPTION
I was trying to use `load_tif` from CropHarvest with the newly exported crop-mask data but it was not possible because the newly exported data had various temporal dimensions (due to exporting longer time series, and in-season data).

So I made some changes so that `load_tif` can infer the temporal dimension.

Let me know what you think!