### PR TITLE
Check failing tasks too

### DIFF
--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -56,7 +56,7 @@ def get_ee_task_list(key: str = "description") -> List[str]:
     return [
         task[key]
         for task in tqdm(task_list, desc="Loading Earth Engine tasks")
-        if task["state"] in ["READY", "RUNNING"]
+        if task["state"] in ["READY", "RUNNING", "FAILED"]
     ]
 
 


### PR DESCRIPTION
This PR includes failed export tasks in the ee task list so they are not needlessly retried.
The underlying issue for these exports for example
```
Error: Element.get: Parameter 'object' is required. (Error code: 3)
```
will still need to be addressed.