### PR TITLE
Add max values for the bands, for easier normalization

### DIFF
--- a/cropharvest/bands.py
+++ b/cropharvest/bands.py
@@ -5,7 +5,7 @@ values for each band
 """
 S1_BANDS = ["VV", "VH"]
 # EarthEngine estimates Sentinel-1 values range from -50 to 1
-S1_MAX_VALUES = [50., 50.]
+S1_MAX_VALUES = [50.0, 50.0]
 S2_BANDS = ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B8A", "B9", "B10", "B11", "B12"]
 S2_MAX_VALUES = [float(1e4)] * len(S2_BANDS)
 ERA5_BANDS = ["temperature_2m", "total_precipitation"]
@@ -15,14 +15,27 @@ ERA5_BANDS = ["temperature_2m", "total_precipitation"]
 # and https://www.guinnessworldrecords.com/world-records/greatest-monthly-rainfall- suggest
 # 10 m is a good estimate. This is (very likely) an overestimate, since the grid is much
 # larger than the areas for which these records were achieved
-ERA5_MAX_VALUES = [329.85, 10.]
+ERA5_MAX_VALUES = [329.85, 10.0]
 SRTM_BANDS = ["elevation", "slope"]
 # max elevation provided by the Google Earth Engine estimate.
 # slope is calculated in degrees by the ee.Terrain.slope function
-SRTM_MAX_VALUES = [6500., 90.]
+SRTM_MAX_VALUES = [6500.0, 90.0]
 
 DYNAMIC_BANDS = S1_BANDS + S2_BANDS + ERA5_BANDS
 STATIC_BANDS = SRTM_BANDS
 
 DYNAMIC_BANDS_MAX = S1_MAX_VALUES + S2_MAX_VALUES + ERA5_MAX_VALUES
 STATIC_BANDS_MAX = SRTM_MAX_VALUES
+
+# These bands are what is created by the Engineer. If the engineer changes, the bands
+# here will need to change (and vice versa)
+REMOVED_BANDS = ["B1", "B10"]
+RAW_BANDS = DYNAMIC_BANDS + STATIC_BANDS
+
+BANDS = [x for x in DYNAMIC_BANDS if x not in REMOVED_BANDS] + STATIC_BANDS + ["NDVI"]
+# NDVI is between 0 and 1
+BANDS_MAX = (
+    [DYNAMIC_BANDS_MAX[i] for i, x in enumerate(DYNAMIC_BANDS) if x not in REMOVED_BANDS]
+    + STATIC_BANDS_MAX
+    + [1.0]
+)

--- a/cropharvest/bands.py
+++ b/cropharvest/bands.py
@@ -5,9 +5,9 @@ values for each band
 """
 S1_BANDS = ["VV", "VH"]
 # EarthEngine estimates Sentinel-1 values range from -50 to 1
-S1_MAX_VALUES = [50, 50]
+S1_MAX_VALUES = [50., 50.]
 S2_BANDS = ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B8A", "B9", "B10", "B11", "B12"]
-S2_MAX_VALUES = [1e4] * len(S2_BANDS)
+S2_MAX_VALUES = [float(1e4)] * len(S2_BANDS)
 ERA5_BANDS = ["temperature_2m", "total_precipitation"]
 # the hottest temperature ever recorded on Earth is 329.85K
 # (https://en.wikipedia.org/wiki/List_of_weather_records#Hottest)
@@ -15,11 +15,11 @@ ERA5_BANDS = ["temperature_2m", "total_precipitation"]
 # and https://www.guinnessworldrecords.com/world-records/greatest-monthly-rainfall- suggest
 # 10 m is a good estimate. This is (very likely) an overestimate, since the grid is much
 # larger than the areas for which these records were achieved
-ERA5_MAX_VALUES = [329.85, 10]
+ERA5_MAX_VALUES = [329.85, 10.]
 SRTM_BANDS = ["elevation", "slope"]
 # max elevation provided by the Google Earth Engine estimate.
 # slope is calculated in degrees by the ee.Terrain.slope function
-SRTM_MAX_VALUES = [6500, 90]
+SRTM_MAX_VALUES = [6500., 90.]
 
 DYNAMIC_BANDS = S1_BANDS + S2_BANDS + ERA5_BANDS
 STATIC_BANDS = SRTM_BANDS

--- a/cropharvest/bands.py
+++ b/cropharvest/bands.py
@@ -1,7 +1,28 @@
+"""
+For easier normalization of the band values (instead of needing to recompute
+the normalization dict with the addition of new data), we provide maximum
+values for each band
+"""
 S1_BANDS = ["VV", "VH"]
+# EarthEngine estimates Sentinel-1 values range from -50 to 1
+S1_MAX_VALUES = [50, 50]
 S2_BANDS = ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B8A", "B9", "B10", "B11", "B12"]
+S2_MAX_VALUES = [1e4] * len(S2_BANDS)
 ERA5_BANDS = ["temperature_2m", "total_precipitation"]
+# the hottest temperature ever recorded on Earth is 329.85K
+# (https://en.wikipedia.org/wiki/List_of_weather_records#Hottest)
+# For rainfall, http://www.bom.gov.au/water/designRainfalls/rainfallEvents/worldRecRainfall.shtml
+# and https://www.guinnessworldrecords.com/world-records/greatest-monthly-rainfall- suggest
+# 10 m is a good estimate. This is (very likely) an overestimate, since the grid is much
+# larger than the areas for which these records were achieved
+ERA5_MAX_VALUES = [329.85, 10]
 SRTM_BANDS = ["elevation", "slope"]
+# max elevation provided by the Google Earth Engine estimate.
+# slope is calculated in degrees by the ee.Terrain.slope function
+SRTM_MAX_VALUES = [6500, 90]
 
 DYNAMIC_BANDS = S1_BANDS + S2_BANDS + ERA5_BANDS
 STATIC_BANDS = SRTM_BANDS
+
+DYNAMIC_BANDS_MAX = S1_MAX_VALUES + S2_MAX_VALUES + ERA5_MAX_VALUES
+STATIC_BANDS_MAX = SRTM_MAX_VALUES

--- a/cropharvest/engineer.py
+++ b/cropharvest/engineer.py
@@ -37,7 +37,7 @@ BANDS = [x for x in DYNAMIC_BANDS if x not in REMOVED_BANDS] + STATIC_BANDS + ["
 BANDS_MAX = (
     [DYNAMIC_BANDS_MAX[i] for i, x in enumerate(DYNAMIC_BANDS) if x not in REMOVED_BANDS]
     + STATIC_BANDS_MAX
-    + [1]
+    + [1.]
 )
 
 

--- a/cropharvest/engineer.py
+++ b/cropharvest/engineer.py
@@ -14,7 +14,7 @@ import h5py
 
 from sklearn.metrics import roc_auc_score, f1_score
 
-from cropharvest.bands import STATIC_BANDS, DYNAMIC_BANDS, STATIC_BANDS_MAX, DYNAMIC_BANDS_MAX
+from cropharvest.bands import STATIC_BANDS, DYNAMIC_BANDS, BANDS, RAW_BANDS, REMOVED_BANDS
 from cropharvest.columns import RequiredColumns, NullableColumns
 from .config import (
     EXPORT_END_DAY,
@@ -28,17 +28,6 @@ from .config import (
 from .utils import DATAFOLDER_PATH, load_normalizing_dict
 
 from typing import cast, Optional, Dict, Union, Tuple, List, Sequence
-
-REMOVED_BANDS = ["B1", "B10"]
-RAW_BANDS = DYNAMIC_BANDS + STATIC_BANDS
-
-BANDS = [x for x in DYNAMIC_BANDS if x not in REMOVED_BANDS] + STATIC_BANDS + ["NDVI"]
-# NDVI is between 0 and 1
-BANDS_MAX = (
-    [DYNAMIC_BANDS_MAX[i] for i, x in enumerate(DYNAMIC_BANDS) if x not in REMOVED_BANDS]
-    + STATIC_BANDS_MAX
-    + [1.]
-)
 
 
 @dataclass
@@ -174,6 +163,12 @@ class TestInstance:
 
 
 class Engineer:
+    """
+    This engineer creates features with BANDS defined in bands.py.
+    If the engineer changes, the bands there will need to change as
+    well.
+    """
+
     def __init__(self, data_folder: Path = DATAFOLDER_PATH) -> None:
         self.data_folder = data_folder
         self.eo_files = data_folder / "eo_data"

--- a/cropharvest/engineer.py
+++ b/cropharvest/engineer.py
@@ -1,3 +1,4 @@
+import enum
 from pathlib import Path
 from datetime import datetime, timedelta
 import geopandas
@@ -13,7 +14,7 @@ import h5py
 
 from sklearn.metrics import roc_auc_score, f1_score
 
-from cropharvest.bands import STATIC_BANDS, DYNAMIC_BANDS
+from cropharvest.bands import STATIC_BANDS, DYNAMIC_BANDS, STATIC_BANDS_MAX, DYNAMIC_BANDS_MAX
 from cropharvest.columns import RequiredColumns, NullableColumns
 from .config import (
     EXPORT_END_DAY,
@@ -30,7 +31,14 @@ from typing import cast, Optional, Dict, Union, Tuple, List, Sequence
 
 REMOVED_BANDS = ["B1", "B10"]
 RAW_BANDS = DYNAMIC_BANDS + STATIC_BANDS
+
 BANDS = [x for x in DYNAMIC_BANDS if x not in REMOVED_BANDS] + STATIC_BANDS + ["NDVI"]
+# NDVI is between 0 and 1
+BANDS_MAX = (
+    [DYNAMIC_BANDS_MAX[i] for i, x in enumerate(DYNAMIC_BANDS) if x not in REMOVED_BANDS]
+    + STATIC_BANDS_MAX
+    + [1]
+)
 
 
 @dataclass

--- a/cropharvest/engineer.py
+++ b/cropharvest/engineer.py
@@ -1,4 +1,3 @@
-import enum
 from pathlib import Path
 from datetime import datetime, timedelta
 import geopandas


### PR DESCRIPTION
Re-iterating through new datasets to calculate the normalizing dict can be onerous. 

This code adds a new constant to `cropharvest.engineer` which exposes the expected maximum values for each band; this can be substituted for normalization of the bands. 