### PR TITLE
[Fix] Double dates in export files

### DIFF
--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -426,7 +426,6 @@ class EarthEngineExporter:
             raise ValueError(f"Start date {start_date} is after end date {end_date}")
 
         ee_bbox = EEBoundingBox.from_bounding_box(bounding_box=bbox, padding_metres=0)
-        general_identifier = f"{bbox_name}_{str(start_date)}_{str(end_date)}"
         if metres_per_polygon is not None:
             regions = ee_bbox.to_polygons(metres_per_patch=metres_per_polygon)
             ids = [f"batch_{i}/{i}" for i in range(len(regions))]
@@ -438,7 +437,7 @@ class EarthEngineExporter:
         for identifier, region in zip(ids, regions):
             return_obj[identifier] = self._export_for_polygon(
                 polygon=region,
-                polygon_identifier=f"{general_identifier}/{identifier}",
+                polygon_identifier=f"{bbox_name}/{identifier}",
                 start_date=start_date,
                 end_date=end_date,
                 file_dimensions=file_dimensions,

--- a/cropharvest/inference.py
+++ b/cropharvest/inference.py
@@ -42,9 +42,9 @@ class Inference:
     @staticmethod
     def start_date_from_str(path: Union[Path, str]) -> datetime:
         dates = re.findall(r"\d{4}-\d{2}-\d{2}", str(path))
-        if len(dates) != 2:
-            raise ValueError(f"{path} should have start and end date")
-        start_date_str, _ = dates
+        if len(dates) < 1:
+            raise ValueError(f"{path} should have at least one date")
+        start_date_str = dates[0]
         start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
         return start_date
 

--- a/test/cropharvest/eo/test_eo.py
+++ b/test/cropharvest/eo/test_eo.py
@@ -131,7 +131,7 @@ def test_export_for_bbox(mock_export_for_polygon, metres_per_polygon, mock_polyg
         mock_export_for_polygon.assert_called_with(
             end_date=end_date,
             polygon=None,
-            polygon_identifier=f"Togo_{start_date}_{end_date}/batch/0",
+            polygon_identifier=f"Togo/batch/0",
             start_date=start_date,
             file_dimensions=None,
             test=True,
@@ -143,7 +143,7 @@ def test_export_for_bbox(mock_export_for_polygon, metres_per_polygon, mock_polyg
                 call(
                     end_date=end_date,
                     polygon=None,
-                    polygon_identifier=f"Togo_{start_date}_{end_date}/batch_{i}/{i}",
+                    polygon_identifier=f"Togo/batch_{i}/{i}",
                     start_date=start_date,
                     file_dimensions=None,
                     test=True,

--- a/test/cropharvest/test_inference.py
+++ b/test/cropharvest/test_inference.py
@@ -1,3 +1,5 @@
+import pytest
+
 from datetime import datetime
 from pathlib import Path
 import numpy as np
@@ -9,6 +11,19 @@ TIF_FILE = Path(__file__).parent / "98-togo_2019-02-06_2020-02-01.tif"
 
 def test_start_date_from_str():
     actual_start_date = Inference.start_date_from_str(TIF_FILE.name)
+    expected_start_date = datetime(2019, 2, 6, 0, 0)
+    assert actual_start_date == expected_start_date
+
+
+def test_start_date_from_str_none():
+    with pytest.raises(ValueError):
+        Inference.start_date_from_str("98-togo")
+
+
+def test_start_date_from_str_more_than_2():
+    actual_start_date = Inference.start_date_from_str(
+        "98-togo_2019-02-06_2020-02-01_2019-02-06_2020-02-01"
+    )
     expected_start_date = datetime(2019, 2, 6, 0, 0)
     assert actual_start_date == expected_start_date
 


### PR DESCRIPTION
`export_for_bbox()` takes a `bbox_name` and appends dates to the end. In most cases the `bbox_name` would be created using the `make_identifier` function and so would already have dates appended. So then the resulting identifier could look like this: "98-togo_2019-02-06_2020-02-01_2019-02-06_2020-02-01" which can cause inference to fail.

The PR removes the additional date appending done in `export_for_bbox` and makes the date extraction more general so it will not fail with different formats.