### PR TITLE
Fix end date in the exporter's load_default_labels function

### DIFF
--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -145,8 +145,8 @@ class EarthEngineExporter:
             start_date=lambda x: x["end_date"]
             - timedelta(days=DAYS_PER_TIMESTEP * DEFAULT_NUM_TIMESTEPS)
         )
-        labels = labels.assign(
-            export_identifier=lambda x: f"{x['index']}-{x[RequiredColumns.DATASET]}"
+        labels["export_identifier"] = labels.apply(
+            lambda x: f"{x['index']}-{x[RequiredColumns.DATASET]}", axis=1
         )
         if dataset:
             labels = labels[labels.dataset == dataset]

--- a/cropharvest/eo/eo.py
+++ b/cropharvest/eo/eo.py
@@ -138,7 +138,9 @@ class EarthEngineExporter:
     ) -> geopandas.GeoDataFrame:
         labels = geopandas.read_file(DATAFOLDER_PATH / LABELS_FILENAME)
         export_end_year = pd.to_datetime(labels[RequiredColumns.EXPORT_END_DATE]).dt.year
-        labels["end_date"] = export_end_year.apply(lambda x: date(x, 12, 12))
+        labels["end_date"] = export_end_year.apply(
+            lambda x: date(x, EXPORT_END_MONTH, EXPORT_END_DAY)
+        )
         labels = labels.assign(
             start_date=lambda x: x["end_date"]
             - timedelta(days=DAYS_PER_TIMESTEP * DEFAULT_NUM_TIMESTEPS)


### PR DESCRIPTION
- [x] Currently, the export end data is (incorrectly) the 12th December. Update it to the `EXPORT_END_DAY` and `EXPORT_END_MONTH`
- [x] The assignment of the export_end_date isn't row-wise in the default_load_labels function, so its a mess. Fix it. 

This blocks #84 and #82